### PR TITLE
[add] カスタムメッセージでサインアップフローを改善

### DIFF
--- a/cohabiCognitoLambda/create-custom-message.js
+++ b/cohabiCognitoLambda/create-custom-message.js
@@ -1,0 +1,33 @@
+/**
+ * Cognito のカスタムメッセージトリガーに登録する関数です
+ * API経由でアプリにリダイレクトします
+ */
+const cofirmEmailURL =
+  "https://gcuoqt6cx9.execute-api.ap-northeast-1.amazonaws.com/confirm";
+const userPoolId = "ap-northeast-1_HiRuznaNt";
+const cognitoClientId = "7t7e3fkhvsfi97t7tpodnfr5hq";
+const redirectURI = "https://cohabi.unison-8225.com/output";
+
+const getEmailMessage = (userName, confirmationCode) => `Hi ${userName}
+<br>
+Click following link to complete signup.
+<br>
+<a href=${cofirmEmailURL}?client_id=${cognitoClientId}&user_name=${userName}&confirmation_code=${confirmationCode}&redirect_uri=${redirectURI}>Click Here</a>
+<br>
+Then, use username and password to signin.`;
+
+exports.handler = (event, context, callback) => {
+  //   console.log("EVENT", event);
+  if (event.userPoolId === userPoolId) {
+    if (event.triggerSource === "CustomMessage_SignUp") {
+      event.response.emailSubject =
+        "Welcome to Cohabi! Please verify your Email Adress.";
+      event.response.emailMessage = getEmailMessage(
+        event.userName,
+        event.request.codeParameter
+      );
+    }
+  }
+
+  callback(null, event);
+};

--- a/cohabiCognitoLambda/verify-email-redirect.js
+++ b/cohabiCognitoLambda/verify-email-redirect.js
@@ -1,0 +1,73 @@
+/**
+ * 指定されたredirect_uriにリダイレクトします
+ * API Gatewayで、/confirm GETに登録します
+ */
+const https = require("https");
+
+const cognitoAuthUri =
+  "https://cohabi-user-alias.auth.ap-northeast-1.amazoncognito.com/confirmUser";
+const getSuccessResponseBody = (redirectUri) => `
+    <HTML>
+    <HEAD>
+        <META HTTP-EQUIV="Refresh" CONTENT="0; URL=${redirectUri}">
+        <TITLE>Success</TITLE>
+    </HEAD>
+    <BODY>
+        <H1>Success Email Confirmation</H1>
+        <A HREF="${redirectUri}">here</A>.
+    </BODY>
+    </HTML>
+`;
+
+exports.handler = (event, context, callback) => {
+  const err = null;
+
+  const {
+    client_id: clientId,
+    user_name: userName,
+    confirmation_code: confirmationCode,
+    redirect_uri: redirectUri,
+  } = event.queryStringParameters;
+
+  if (!clientId) err = "client_id param is required";
+  if (!userName) err = "user_name param is required";
+  if (!confirmationCode) err = "confirmation_code param is required";
+  if (!redirectUri) err = "redirect_uri param is required";
+
+  if (err) {
+    callback(null, {
+      statusCode: "400",
+      body: JSON.stringify({ error: err }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    return;
+  }
+
+  https
+    .get(
+      `${cognitoAuthUri}?client_id=${clientId}&user_name=${userName}&confirmation_code=${confirmationCode}`,
+      (res) => {
+        callback(null, {
+          statusCode: "301",
+          body: getSuccessResponseBody(redirectUri),
+          headers: {
+            "Content-Type": "text/html; charset=UTF-8",
+          },
+        });
+        return;
+      }
+    )
+    .on("error", (e) => {
+      console.error(e);
+      callback(null, {
+        statusCode: "400",
+        body: JSON.stringify({ error: e.message }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+      return;
+    });
+};


### PR DESCRIPTION
## 概要
- Cognitoにサインアップ時、カスタムメッセージとリダイレクトリンクを生成します
  - ユーザが該当リンクを踏むと、Eメール検証が行われたのち、フロントエンドトップページにリダイレクトします

## 詳細
1. ユーザはフロントエンドからサインアップ
1. Cognitoがリクエストを受け、カスタムメッセージトリガーのLambdaを呼ぶ
1. Lambdaはリダイレクトリンクを含むカスタムメッセージを生成
1. Cognitoが該当メッセージをユーザに送信
1. ユーザはリダイレクトリンクをクリックする
1. API Gateway -> Lambdaを経由してCognitoにてEメールアドレスの確認が行われる
1. 確認が取れたらフロントエンドにリダイレクトする
1. なお、1のサインアップ後フロントエンド画面は「サインアップ済」ページに飛び、メールのリンクを踏むように案内する

## その他
- すでに、このLambda関数は動いています