### PR TITLE
カテゴリの取得/更新機能を追加

### DIFF
--- a/cohabiBackendAPILambda/prod_env/Dynamo_Get_Request.py
+++ b/cohabiBackendAPILambda/prod_env/Dynamo_Get_Request.py
@@ -45,19 +45,25 @@ class Get_Request:
             KeyConditionExpression=Key("ID").eq(GroupID) & Key("DATA_TYPE").begins_with("No"))
 
         if len(dynamoData["Items"]) == 0:
-            
+
             # categoriesの情報がない場合の処理(初期情報を扱う)
             pass
 
         for f in dynamoData["Items"]:
             bodyItems.append({
                 "id": f["DATA_TYPE"],
-                "index": int(f["DATA_TYPE"].split('_')[1]),
+                # DBに保持しているindexをそのまま使用
+                "index": int(f["INDEX"]),
                 "name": f["DATA_VALUE"],
                 "disabled": f["DISABLED"]
             })
 
-        return bodyItems
+        # DBから取得したindexの情報を使用してソートする
+        sortedBodyItems = []
+        if len(bodyItems) != 0:
+            sortedBodyItems = sorted(bodyItems, key=lambda item: item['index'])
+
+        return sortedBodyItems
 
     def todos(self):
         bodyItems = []


### PR DESCRIPTION
Closes #2

- カテゴリの取得
  -  配列順序を整える処理を追加
- カテゴリの更新
  - リクエストbody=配列を受け取り、batch write APIによりテーブルを更新します。
  - DATA_TYPEは、各行の`ID`として使用。
     - 空の場合は新規追加行なので新たに`ID`を生成
   - INDEXは、各行の`順序`として使用
     - リクエストbodyの配列順序を維持してDBに登録する